### PR TITLE
Added --skip-gemsets test

### DIFF
--- a/fast/ruby-1.8.7_comment_test.sh
+++ b/fast/ruby-1.8.7_comment_test.sh
@@ -7,3 +7,15 @@ rvm reinstall 1.8.7-ntest      # status=0
 rvm 1.8.7-ntest do ruby -v     # match=/1.8.7/
 rvm install 1.8.7-ntest        # status=0; match=/Already installed/
 rvm remove 1.8.7-ntest         # status=0; match=/Removing/
+rvm install ruby-1.8.7 --skip-gemsets # status=0; match=/Skipped importing default gemsets/
+
+source "$rvm_path/scripts/rvm"
+rvm use 1.8.7
+gem list
+# match!=/rvm/
+# match!=/rubygems-bundler/
+# match!=/bundler/
+# match!=/rake/
+
+: reset
+rvm remove 1.8.7


### PR DESCRIPTION
No confident in this test. For some reason the ruby-1.8.7-ntest would not work. Don't quite get how that works. With the normal 1.8.7 ruby name the test works correctly. Does appending the ntest do anything different? take a different path through the script?

Adam
