### PR TITLE
Adding a test for rvm gemset use with an appended --create flag

### DIFF
--- a/fast/gemsets_comment_test.sh
+++ b/fast/gemsets_comment_test.sh
@@ -24,6 +24,12 @@ rm haml.gems
 gem list                    # match=/haml/
 rvm --force gemset delete test_gemset
 
+: use/create
+rvm --force gemset delete test_gemset
+rvm gemset use test_gemset --create # status=0 ; match=/Using /
+rvm current                         # match=/test_gemset/
+rvm --force gemset delete test_gemset
+
 : cleanup
 ls ~/.rvm/wrappers | grep test_gemset # status!=0
 ls -l ~/.rvm/bin   | grep test_gemset # status!=0


### PR DESCRIPTION
Here's a test for the issue that I was seeing-- the tests failed before I had rvm commit 0e9c38cfa9 and passed after I updated to include that commit.

Thank you so much for the quick fix!! <3 <3 <3
