### PR TITLE
Add test for feature-add-recommended-ruby-env

### DIFF
--- a/fast/use_comment_test.sh
+++ b/fast/use_comment_test.sh
@@ -10,3 +10,4 @@ rvm use 1.8.7           # status=0; match=/Using / ; env[GEM_HOME]=/1.8.7/
 rvm current             # match=/1.8.7/
 command rvm use 1.9.2   # status=0; match!=/Using /; env[GEM_HOME]!=/1.9.2/ ; match=/RVM is not a function/
 rvm use 1.9.2           # status=0; match=/Using / ; env[GEM_HOME]=/1.9.2/
+rvm use 1.9.1           # status=1; env[rvm_recommended_ruby]=/rvm install ruby-1.9.1/


### PR DESCRIPTION
This test exercises and checks the environment variable set when a ruby is recommended for installation when use'd but not already installed.

See colindean/rvm@d15ca7293715735ed9fd46e1c3968b6dada861aa for the added code.

See also wayneeseguin/rvm#1074 for the pull request containing the code this tests.
