### PR TITLE
EXIT traps that print to stdout shouldn't break process substitution

### DIFF
--- a/fast/trap_subshell_comment_test.sh
+++ b/fast/trap_subshell_comment_test.sh
@@ -1,0 +1,6 @@
+source "$rvm_path/scripts/rvm"
+
+eval 'shell_session_update() { echo hi'$'\n''}' # status=0
+typeset -f shell_session_update # status=0
+
+echo $(cd . > /dev/null && echo a) # status=0; match=/^a$/


### PR DESCRIPTION
OS X sets a trap on EXIT to call `shell_session_update`, this calls `shell_session_save` which will print to stdout. Normally this is not a problem for subshells instantiated like `$(...)`, because the traps are apparently not inherited by (at least these types of) subshells. However, rvm re-installs this trap, (even from within subshells) when you call something like `cd` (which rvm overrides).

Basically:

    trap 'echo trapped' EXIT
    a=$(echo a)

Will not have the `EXIT` trap called inside the `$(...)`, and will result in `a=a`. However:

    a=$(trap 'echo trapped' EXIT; echo a)

Will have the trap called, and will result in `a=a trapped`.

The latter is what rvm ends up doing when it's loaded by its version of `cd`, and you do something like:

    a=$(cd somewhere && pwd)

Perhaps the overridden shell commands should never install the exit trap? Or rvm could detect when it's being run inside a subshell where it's helpers aren't needed and not run any of the init code?