### PR TITLE
Fix TruffleRuby test to use the intended version

### DIFF
--- a/long/truffleruby_comment_test.sh
+++ b/long/truffleruby_comment_test.sh
@@ -7,5 +7,5 @@ rvm remove truffleruby # status=0; match=/removing.+truffleruby/
 
 ## Test that the right version is installed (#4633)
 rvm install truffleruby-1.0.0-rc13 # status=0; match!=/Already installed/
-rvm truffleruby do ruby -v # status=0; match=/truffleruby 1.0.0-rc13/
+rvm truffleruby-1.0.0-rc13 do ruby -v # status=0; match=/truffleruby 1.0.0-rc13/
 rvm remove truffleruby-1.0.0-rc13


### PR DESCRIPTION
Fixes https://github.com/rvm/rvm-test/pull/27 which was unfortunately incorrect.
I didn't notice the bug since the CI of `rvm-test` is broken, e.g., https://travis-ci.org/rvm/rvm-test/builds/518978364, which is one more reason for https://github.com/rvm/rvm/issues/4663.
So I only noticed on the update of rvm-test in https://github.com/rvm/rvm/pull/4673

See rvm/rvm#4662

cc @pkuczynski